### PR TITLE
52929 - Update HttpErrorBoyResult to inherit from FormattedJsonResult

### DIFF
--- a/src/Dfe.Spi.Common/Dfe.Spi.Common.Http.Server/Dfe.Spi.Common.Http.Server.csproj
+++ b/src/Dfe.Spi.Common/Dfe.Spi.Common.Http.Server/Dfe.Spi.Common.Http.Server.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>2.2.0</Version>
+    <Version>2.2.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Dfe.Spi.Common/Dfe.Spi.Common.Http.Server/FormattedJsonResult.cs
+++ b/src/Dfe.Spi.Common/Dfe.Spi.Common.Http.Server/FormattedJsonResult.cs
@@ -6,7 +6,8 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
 namespace Dfe.Spi.Common.Http.Server
-{// Created this as having issues with .NET 3.1 and customising serialization settings:
+{
+    // Created this as having issues with .NET 3.1 and customising serialization settings:
     //    - OTB you cannot provide JsonSerializerSettings as the default serialization is no longer Newtonsoft
     //    - Adding the Newtonsoft path package fixed when running but caused issues with the use of DefaultHttpRequest in tests
     //    - Adding json formatters in startup

--- a/src/Dfe.Spi.Common/Dfe.Spi.Common.Http.Server/HttpErrorBodyResult.cs
+++ b/src/Dfe.Spi.Common/Dfe.Spi.Common.Http.Server/HttpErrorBodyResult.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// An action result which returns error information.
     /// </summary>
-    public class HttpErrorBodyResult : JsonResult
+    public class HttpErrorBodyResult : FormattedJsonResult
     {
         /// <summary>
         /// Initialises a new instance of the
@@ -43,9 +43,8 @@
         /// </param>
         public HttpErrorBodyResult(
             HttpErrorBody errorBody)
-            : base(errorBody)
+            : base(errorBody, errorBody.StatusCode)
         {
-            this.StatusCode = (int)errorBody.StatusCode;
         }
 
         private static HttpErrorBody CreateHttpErrorBody(


### PR DESCRIPTION
Needed as otherwise have errors in .NET core 3.1